### PR TITLE
Ensure that Vector component IDs are globally unique.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/VictoriaMetrics/metricsql v0.84.3
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
+	github.com/stretchr/testify v1.10.0
 	go.miloapis.com/milo v0.1.0
 	golang.org/x/sync v0.15.0
 	k8s.io/api v0.33.1
@@ -56,6 +57,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect

--- a/internal/controller/vector_configuration_test.go
+++ b/internal/controller/vector_configuration_test.go
@@ -1,0 +1,128 @@
+package controller
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"go.datum.net/telemetry-services-operator/api/v1alpha1"
+)
+
+func TestCreateVectorConfiguration(t *testing.T) {
+	tests := []struct {
+		name         string
+		exportPolicy *v1alpha1.ExportPolicy
+		assert       func(t *testing.T, ep *v1alpha1.ExportPolicy, vectorConfig map[string]any)
+	}{
+		{
+			name:         "project filter is present when no filters are specified",
+			exportPolicy: newExportPolicy(),
+			assert: func(t *testing.T, ep *v1alpha1.ExportPolicy, vectorConfig map[string]any) {
+				vectorSources := vectorConfig["sources"].(map[string]any)
+
+				if assert.Len(t, vectorSources, 1) {
+					sources := slices.Collect(maps.Keys(vectorSources))
+
+					source := vectorSources[sources[0]].(map[string]any)
+					if assert.Contains(t, source, "query") && assert.Contains(t, source["query"], "match[]") {
+						query := source["query"].(map[string]any)
+						matchers := query["match[]"].([]string)
+						assert.Contains(t, matchers[0], `resourcemanager_datumapis_com_project_name="test-project"`)
+					}
+				}
+			},
+		},
+		{
+			name: "project filter is present when filters are specified",
+			exportPolicy: newExportPolicy(func(ep *v1alpha1.ExportPolicy) {
+				ep.Spec.Sources[0].Metrics.MetricsQL = `{job="my-job"}`
+			}),
+			assert: func(t *testing.T, ep *v1alpha1.ExportPolicy, vectorConfig map[string]any) {
+				vectorSources := vectorConfig["sources"].(map[string]any)
+
+				if assert.Len(t, vectorSources, 1) {
+					sources := slices.Collect(maps.Keys(vectorSources))
+
+					source := vectorSources[sources[0]].(map[string]any)
+					if assert.Contains(t, source, "query") && assert.Contains(t, source["query"], "match[]") {
+						query := source["query"].(map[string]any)
+						matchers := query["match[]"].([]string)
+						assert.Contains(t, matchers[0], `resourcemanager_datumapis_com_project_name="test-project"`)
+					}
+				}
+			},
+		},
+		{
+			name: "matching source and sink name produces unique component names",
+			exportPolicy: newExportPolicy(func(ep *v1alpha1.ExportPolicy) {
+				ep.Spec.Sinks = []v1alpha1.TelemetrySink{
+					{
+						Name:    "source",
+						Sources: []string{"source"},
+						Target: &v1alpha1.SinkTarget{
+							PrometheusRemoteWrite: &v1alpha1.PrometheusRemoteWriteSink{},
+						},
+					},
+				}
+			}),
+			assert: func(t *testing.T, ep *v1alpha1.ExportPolicy, vectorConfig map[string]any) {
+				sourceComponentNames := slices.Collect(maps.Keys(vectorConfig["sources"].(map[string]any)))
+				sinkComponentNames := slices.Collect(maps.Keys(vectorConfig["sinks"].(map[string]any)))
+
+				for _, sourceName := range sourceComponentNames {
+					assert.NotContains(t, sinkComponentNames, sourceName)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := &ExportPolicyReconciler{}
+
+			vectorConfig := reconciler.createVectorConfiguration(context.Background(), "test-project", nil, tt.exportPolicy)
+
+			tt.assert(t, tt.exportPolicy, vectorConfig)
+		})
+	}
+}
+
+func newExportPolicy(opts ...func(*v1alpha1.ExportPolicy)) *v1alpha1.ExportPolicy {
+	p := &v1alpha1.ExportPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
+			Namespace: "test-namespace",
+			Name:      "test-exportpolicy",
+		},
+		Spec: v1alpha1.ExportPolicySpec{
+			Sources: []v1alpha1.TelemetrySource{
+				{
+					Name: "source",
+					Metrics: &v1alpha1.MetricSource{
+						MetricsQL: "{}",
+					},
+				},
+			},
+			Sinks: []v1alpha1.TelemetrySink{
+				{
+					Name:    "sink",
+					Sources: []string{"source"},
+					Target: &v1alpha1.SinkTarget{
+						PrometheusRemoteWrite: &v1alpha1.PrometheusRemoteWriteSink{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
 )
 
 const (
@@ -197,7 +197,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 


### PR DESCRIPTION
Vector requires that all component IDs do not have conflicting names, regardless of their type. This is likely to ensure that internal telemetry does not end up with label values that conflict with each other.

Bootstrapped some unit tests to cover this, and to ensure the source project filter is always present.