### PR TITLE
chore: embed image tag in kustomize bundle at publish time

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,4 +28,6 @@ jobs:
     with:
       bundle-name: ghcr.io/datum-cloud/telemetry-services-operator-kustomize
       bundle-path: config
+      image-name: ghcr.io/datum-cloud/telemetry-services-operator
+      image-overlays: config/manager
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pass `image-name` and `image-overlays` inputs to `publish-kustomize-bundle.yaml@v1.14.0` so the "Set Image Tags in Kustomize Overlays" step runs during CI
- Without these inputs the step is conditional on both being non-empty, so it is silently skipped — the bundle is published with `newTag: latest` in `config/manager/kustomization.yaml` instead of the actual build tag
- This caused `ImagePullBackOff` in staging because FluxCD deploys the bundle as-is and the `latest` tag resolves to nothing useful

## Test plan

- [ ] Merge and confirm CI runs the "Set Image Tags in Kustomize Overlays" step (check workflow run logs for `publish-kustomize-bundles` job)
- [ ] Confirm the published OCI bundle at `ghcr.io/datum-cloud/telemetry-services-operator-kustomize` has `newTag` set to the build tag (not `latest`) in `config/manager/kustomization.yaml`
- [ ] Confirm staging deployment rolls out successfully without `ImagePullBackOff`