### PR TITLE
chore: publish images and kustomize bundles to milo-os org

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,8 @@ jobs:
       attestations: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.14.0
     with:
-      image-name: telemetry-services-operator
+      image-name: telemetry
+      registry-organization: milo-os
       platforms: linux/amd64,linux/arm64
     secrets: inherit
 
@@ -26,8 +27,8 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
     with:
-      bundle-name: ghcr.io/datum-cloud/telemetry-services-operator-kustomize
+      bundle-name: ghcr.io/milo-os/telemetry-kustomize
       bundle-path: config
-      image-name: ghcr.io/datum-cloud/telemetry-services-operator
+      image-name: ghcr.io/milo-os/telemetry
       image-overlays: config/manager
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/milo-os/telemetry=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
 ##@ Deployment
@@ -159,7 +159,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/milo-os/telemetry=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
 .PHONY: undeploy

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,8 +2,8 @@ resources:
 - manager.yaml
 kind: Kustomization
 images:
-- name: ghcr.io/datum-cloud/telemetry-services-operator
-  newName: ghcr.io/datum-cloud/telemetry-services-operator
+- name: ghcr.io/milo-os/telemetry
+  newName: ghcr.io/milo-os/telemetry
   newTag: latest
 
   # Create a config map with the configuration to use for the operator.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --server-config=/config/service-config.yaml
-        image: ghcr.io/datum-cloud/telemetry-services-operator:latest
+        image: ghcr.io/milo-os/telemetry:latest
         name: manager
         ports: []
         securityContext:


### PR DESCRIPTION
## Summary

Updates the publish workflow and default image overlay to use the `milo-os` GHCR namespace, following the repo move from `datum-cloud/telemetry-services-operator` to `milo-os/telemetry`. Matches the convention used by `milo-os/billing` and `milo-os/activity`.

- Container image: `ghcr.io/datum-cloud/telemetry-services-operator` → `ghcr.io/milo-os/telemetry`
- Kustomize bundle: `ghcr.io/datum-cloud/telemetry-services-operator-kustomize` → `ghcr.io/milo-os/telemetry-kustomize`
- `config/manager/{kustomization,manager}.yaml` default image refs updated

## Out of scope

Kept intentionally narrow to avoid coupling unrelated changes:

- Go module path (`go.datum.net/telemetry-services-operator`) — separate refactor, affects every importer
- `app.kubernetes.io/name: telemetry-services-operator` labels — renaming would break selector matching on existing Pods
- Namespace name `telemetry-services-operator-system`, kustomize `namePrefix` — would force a hard cutover
- Tests, Makefile builder names, README links

These can follow as separate PRs once the publishing migration is bedded in.

## Companion change

The `datum-cloud/infra` repo needs a follow-up PR to switch all OCIRepository references from `oci://ghcr.io/datum-cloud/telemetry-services-operator-kustomize` to `oci://ghcr.io/milo-os/telemetry-kustomize`, rename Flux Kustomizations to `telemetry-system`, drop the legacy image-updater files in favour of OCIRepository semver filters, and remove the entry from `github/Pulumi.{staging,prod}.yaml`'s `repositories-publishing-images`. Plan drafted separately.

## Cutover order

1. Merge this PR. CI should publish the first artifacts under `ghcr.io/milo-os/telemetry*`.
2. Cut a release tag (`v0.2.2` or similar) so the OCI bundle gets a stable semver tag for production.
3. Open the infra repo PR pointing at the new paths.
4. After Flux has reconciled in staging + production, the legacy `ghcr.io/datum-cloud/telemetry-services-operator*` packages can be retired and the `datum-cloud` GitHub WIF binding revoked.

## Test plan

- [ ] CI on this branch publishes to `ghcr.io/milo-os/telemetry` and `ghcr.io/milo-os/telemetry-kustomize` on merge to main
- [ ] `flux pull artifact oci://ghcr.io/milo-os/telemetry-kustomize` succeeds (manual smoke test)
- [ ] The published bundle, when applied via kustomize, points to `ghcr.io/milo-os/telemetry:<tag>`