### PR TITLE
docs: add query layer OpenAPI 3.0 spec

### DIFF
--- a/queryapi/openapi.yaml
+++ b/queryapi/openapi.yaml
@@ -231,37 +231,12 @@ paths:
           $ref: "#/components/responses/UnexpectedError"
 
   /api/v1/query:
-    get:
-      operationId: promQuery
-      summary: Instant metric query (mimics Prometheus's /api/v1/query)
-      tags: [metrics]
-      parameters:
-        - $ref: "#/components/parameters/PromQLQuery"
-        - name: time
-          in: query
-          description: Evaluation instant. Defaults to now.
-          schema:
-            type: string
-            format: date-time
-        - $ref: "#/components/parameters/QueryTimeout"
-      responses:
-        "200":
-          description: One sample per matching series, evaluated at `time`.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PromInstantQueryResponse"
-        "400":
-          $ref: "#/components/responses/BadQuery"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        default:
-          $ref: "#/components/responses/UnexpectedError"
     post:
-      operationId: promQueryForm
+      operationId: promQuery
       summary: >-
-        Instant metric query, form-encoded (Grafana's Prometheus datasource
-        POSTs by default; this is the same operation as GET /api/v1/query)
+        Instant metric query, form-encoded (mimics Prometheus's
+        /api/v1/query; POST-only, matching Grafana's Prometheus datasource
+        default request mode)
       tags: [metrics]
       requestBody:
         required: true
@@ -284,39 +259,12 @@ paths:
           $ref: "#/components/responses/UnexpectedError"
 
   /api/v1/query_range:
-    get:
-      operationId: promQueryRange
-      summary: Range metric query (mimics Prometheus's /api/v1/query_range)
-      tags: [metrics]
-      parameters:
-        - $ref: "#/components/parameters/PromQLQuery"
-        - $ref: "#/components/parameters/Start"
-        - $ref: "#/components/parameters/End"
-        - name: step
-          in: query
-          required: true
-          description: Resolution step duration, e.g. "30s", "5m".
-          schema:
-            type: string
-        - $ref: "#/components/parameters/QueryTimeout"
-      responses:
-        "200":
-          description: A series of samples per matching series across the range.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PromRangeQueryResponse"
-        "400":
-          $ref: "#/components/responses/BadQuery"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        default:
-          $ref: "#/components/responses/UnexpectedError"
     post:
-      operationId: promQueryRangeForm
+      operationId: promQueryRange
       summary: >-
-        Range metric query, form-encoded (Grafana's Prometheus datasource
-        POSTs by default; this is the same operation as GET /api/v1/query_range)
+        Range metric query, form-encoded (mimics Prometheus's
+        /api/v1/query_range; POST-only, matching Grafana's Prometheus
+        datasource default request mode)
       tags: [metrics]
       requestBody:
         required: true
@@ -476,18 +424,6 @@ components:
         type: string
       example: '{service_name="compute-workload", severity="ERROR"} |= "timeout"'
 
-    PromQLQuery:
-      name: query
-      in: query
-      required: true
-      description: >-
-        PromQL-style label-matched series selector, e.g.
-        `cpu_usage{service="foo"}`. Aggregation functions (sum, avg, rate) are
-        not yet supported and are rejected with 400.
-      schema:
-        type: string
-      example: 'cpu_usage{service="compute-workload"}'
-
     Start:
       name: start
       in: query
@@ -523,16 +459,6 @@ components:
         type: string
         enum: [backward, forward]
         default: backward
-
-    QueryTimeout:
-      name: timeout
-      in: query
-      description: >-
-        Evaluation timeout, e.g. "30s", matching Prometheus's own /query and
-        /query_range timeout param. Accepted for client compatibility; not
-        yet enforced.
-      schema:
-        type: string
 
   responses:
     BadQuery:
@@ -662,6 +588,11 @@ components:
       properties:
         query:
           type: string
+          description: >-
+            PromQL-style label-matched series selector, e.g.
+            `cpu_usage{service="foo"}`. Aggregation functions (sum, avg,
+            rate) are not yet supported and are rejected with 400.
+          example: 'cpu_usage{service="compute-workload"}'
         time:
           type: string
         timeout:
@@ -673,6 +604,11 @@ components:
       properties:
         query:
           type: string
+          description: >-
+            PromQL-style label-matched series selector, e.g.
+            `cpu_usage{service="foo"}`. Aggregation functions (sum, avg,
+            rate) are not yet supported and are rejected with 400.
+          example: 'cpu_usage{service="compute-workload"}'
         start:
           type: string
         end:

--- a/queryapi/openapi.yaml
+++ b/queryapi/openapi.yaml
@@ -6,7 +6,34 @@ info:
     `datumctl` and the customer cloud portal. Design rationale lives in
     datum-cloud/enhancements, enhancements/telemetry/query-layer/README.md
     (see the "HTTP API contract" section).
-  version: "0.1.0"
+
+
+    The log endpoints below deliberately mimic Loki's HTTP API
+    (`/loki/api/v1/query`, `/query_range`, `/label`, `/label/{name}/values`,
+    `/series`) rather than a bespoke shape, so existing Loki-aware tooling —
+    Grafana's Loki datasource in particular — can query this service with no
+    custom integration. LogQL itself was never the mismatch (it's Loki's own
+    query language, and the subset described below is what this service
+    accepts); only the endpoint paths and response envelope changed to match.
+
+
+    Two things this does **not** adopt from real Loki: (1) tenancy is never
+    read from a client-supplied header (real Loki uses `X-Scope-OrgID`, which
+    puts tenancy in the caller's control — see the query-layer design doc's
+    rejection of that model). `project_id` is always resolved server-side from
+    the request context `milo-api` populates, for every endpoint below
+    including label/series discovery — there is no code path where a client
+    can see another project's labels, series, or log lines. (2) `/loki/api/v1/tail`
+    (Loki's live-tail endpoint, a WebSocket upgrade) is intentionally not
+    included in this revision — tracked as a follow-up once the tail
+    transport (chunked HTTP vs. WebSocket) is decided.
+
+
+    Metrics (`/metrics/query`, `/metrics/query_range`) are a separate concern
+    from the Loki mimicry above — Loki has no metrics endpoints of its own —
+    and are specced here so `datumctl`/portal work can start, but return 501
+    until implemented.
+  version: "0.2.0"
 servers:
   - url: "/projects/{projectId}/control-plane/apis/{telemetryGroup}/v1"
     description: >-
@@ -24,24 +51,28 @@ security:
   - bearerAuth: []
 
 paths:
-  /logs:
+  /loki/api/v1/query:
     get:
-      operationId: queryLogs
-      summary: Buffered log query over a time window
+      operationId: lokiQuery
+      summary: Instant log query (mimics Loki's /loki/api/v1/query)
       tags: [logs]
       parameters:
         - $ref: "#/components/parameters/LogQLQuery"
-        - $ref: "#/components/parameters/Since"
-        - $ref: "#/components/parameters/Until"
         - $ref: "#/components/parameters/Limit"
-        - $ref: "#/components/parameters/Cursor"
+        - name: time
+          in: query
+          description: Evaluation instant. Defaults to now.
+          schema:
+            type: string
+            format: date-time
+        - $ref: "#/components/parameters/Direction"
       responses:
         "200":
-          description: Matching log lines, most recent first.
+          description: Matching log lines, as Loki-shaped streams.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LogsResponse"
+                $ref: "#/components/schemas/LokiQueryResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -49,27 +80,139 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /logs/tail:
+  /loki/api/v1/query_range:
     get:
-      operationId: tailLogs
-      summary: Streaming log query (datumctl logs --tail)
-      description: >-
-        Chunked HTTP response; the connection stays open and new matching log
-        lines are flushed as they are ingested. Delivery is at-least-once —
-        duplicate lines are possible at cursor boundaries, matching the
-        `kubectl logs --follow` contract. Each chunk is one JSON-encoded
-        LogEntry object, newline-delimited.
+      operationId: lokiQueryRange
+      summary: Range log query (mimics Loki's /loki/api/v1/query_range)
       tags: [logs]
       parameters:
         - $ref: "#/components/parameters/LogQLQuery"
-        - $ref: "#/components/parameters/Since"
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Direction"
       responses:
         "200":
-          description: Newline-delimited stream of LogEntry objects.
+          description: Matching log lines over [start,end], as Loki-shaped streams.
           content:
-            application/x-ndjson:
+            application/json:
               schema:
-                $ref: "#/components/schemas/LogEntry"
+                $ref: "#/components/schemas/LokiQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /loki/api/v1/label:
+    get:
+      operationId: lokiLabelNames
+      summary: List label names in use (mimics Loki's /loki/api/v1/label)
+      description: >-
+        Returns `service_name` and `severity` (the fixed schema columns)
+        unioned with the distinct keys currently present in `LogAttributes`/
+        `ResourceAttributes`, scoped to the caller's project_id — a project
+        never sees a label name that only exists in another project's data.
+      tags: [discovery]
+      parameters:
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+      responses:
+        "200":
+          description: Label names.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LokiStringListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /loki/api/v1/label/{name}/values:
+    get:
+      operationId: lokiLabelValues
+      summary: >-
+        List distinct values for one label (mimics Loki's
+        /loki/api/v1/label/{name}/values)
+      description: >-
+        `name=service_name` and `name=severity` read the corresponding fixed
+        column; any other name reads `LogAttributes[name]`/
+        `ResourceAttributes[name]`. Scoped to the caller's project_id, same as
+        every other endpoint here.
+      tags: [discovery]
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: severity
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+        - name: query
+          in: query
+          description: >-
+            Optional LogQL label-matcher subset (no line filters) to further
+            scope which streams' values are considered, e.g.
+            `{service_name="foo"}`.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Distinct values for the named label.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LokiStringListResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /loki/api/v1/series:
+    get:
+      operationId: lokiSeries
+      summary: >-
+        List distinct label-sets / streams matching selectors (mimics Loki's
+        /loki/api/v1/series)
+      description: >-
+        Returned label-sets are bounded to the fixed schema columns
+        (`service_name`, `severity`) plus a small, explicitly allowlisted set
+        of common attribute keys — **not** every key present in
+        `LogAttributes`/`ResourceAttributes`. Including every dynamic
+        attribute key in the combination would make the distinct-combination
+        count unbounded (a cross product over arbitrary per-record JSON
+        keys), which doesn't scale as a discovery query. The allowlist itself
+        is an implementation detail to be defined when this endpoint is
+        built (tracked in the client-wiring issue), not part of this spec.
+      tags: [discovery]
+      parameters:
+        - name: match[]
+          in: query
+          required: true
+          description: >-
+            One or more LogQL label-matcher subset selectors (no line
+            filters), e.g. `{service_name="foo"}`. At least one is required,
+            matching Loki's own /series contract.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+      responses:
+        "200":
+          description: Distinct label-sets matching the given selectors.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LokiSeriesResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -111,18 +254,8 @@ paths:
       tags: [metrics]
       parameters:
         - $ref: "#/components/parameters/PromQLQuery"
-        - name: start
-          in: query
-          required: true
-          schema:
-            type: string
-            format: date-time
-        - name: end
-          in: query
-          required: true
-          schema:
-            type: string
-            format: date-time
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
         - name: step
           in: query
           required: true
@@ -178,17 +311,17 @@ components:
         type: string
       example: 'cpu_usage{service="compute-workload"}'
 
-    Since:
-      name: since
+    Start:
+      name: start
       in: query
       description: >-
-        Relative ("1h", "30m") or absolute timestamp. Filters ObservedTimestamp.
-        Defaults to 1h before now.
+        Relative ("1h", "30m") or absolute timestamp lower bound. Filters
+        ObservedTimestamp. Defaults to 1h before now.
       schema:
         type: string
 
-    Until:
-      name: until
+    End:
+      name: end
       in: query
       description: Relative or absolute timestamp upper bound. Defaults to now.
       schema:
@@ -203,12 +336,16 @@ components:
         maximum: 1000
         minimum: 1
 
-    Cursor:
-      name: cursor
+    Direction:
+      name: direction
       in: query
-      description: Opaque pagination cursor from a previous response's nextCursor.
+      description: >-
+        Sort order. Only "backward" (most recent first) is supported today;
+        "forward" is rejected with 400.
       schema:
         type: string
+        enum: [backward, forward]
+        default: backward
 
   responses:
     BadQuery:
@@ -218,61 +355,110 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/LokiErrorResponse"
     Unauthorized:
       description: Missing or invalid bearer token.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/LokiErrorResponse"
     UnexpectedError:
       description: >-
         Any error status not explicitly listed above, including 501 Not
         Implemented — every handler in the current scaffold is a stub and
-        returns this until the ClickHouse-backed implementation lands.
+        returns this until the ClickHouse/JetStream-backed implementation
+        lands.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            $ref: "#/components/schemas/LokiErrorResponse"
 
   schemas:
-    Error:
+    LokiErrorResponse:
       type: object
-      required: [message]
+      required: [status, error]
       properties:
-        message:
+        status:
+          type: string
+          enum: [error]
+        errorType:
+          type: string
+          example: bad_data
+        error:
           type: string
 
-    LogEntry:
+    LokiStream:
       type: object
-      required: [timestamp, service, severity, body]
+      required: [stream, values]
       properties:
-        timestamp:
-          type: string
-          format: date-time
-          description: ObservedTimestamp — set by the OTel Collector on receipt.
-        service:
-          type: string
-        severity:
-          type: string
-          example: ERROR
-        body:
-          type: string
-        labels:
+        stream:
           type: object
           additionalProperties:
             type: string
+          description: >-
+            The label set for this stream: `service_name`, `severity`, and
+            any dynamic attribute keys the query touched.
+        values:
+          type: array
+          description: >-
+            [nanosecondTimestamp, logLine] pairs, both strings, matching
+            Loki's own /query and /query_range value encoding.
+          items:
+            type: array
+            items:
+              type: string
+            minItems: 2
+            maxItems: 2
 
-    LogsResponse:
+    LokiQueryResponse:
       type: object
-      required: [results]
+      required: [status, data]
       properties:
-        results:
+        status:
+          type: string
+          enum: [success]
+        data:
+          type: object
+          required: [resultType, result]
+          properties:
+            resultType:
+              type: string
+              enum: [streams]
+              description: >-
+                Always "streams" for the LogQL subset this service accepts.
+                Loki's "vector"/"matrix" result types apply to metric-style
+                log queries (count_over_time, rate, ...), which are rejected
+                at parse time — see the LogQLQuery parameter description.
+            result:
+              type: array
+              items:
+                $ref: "#/components/schemas/LokiStream"
+
+    LokiStringListResponse:
+      type: object
+      required: [status, data]
+      properties:
+        status:
+          type: string
+          enum: [success]
+        data:
           type: array
           items:
-            $ref: "#/components/schemas/LogEntry"
-        nextCursor:
+            type: string
+
+    LokiSeriesResponse:
+      type: object
+      required: [status, data]
+      properties:
+        status:
           type: string
+          enum: [success]
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
 
     MetricSample:
       type: object

--- a/queryapi/openapi.yaml
+++ b/queryapi/openapi.yaml
@@ -1,0 +1,304 @@
+openapi: 3.0.3
+info:
+  title: Telemetry Query Layer API
+  description: >-
+    Tenant-scoped query API over ClickHouse for logs and metrics, serving
+    `datumctl` and the customer cloud portal. Design rationale lives in
+    datum-cloud/enhancements, enhancements/telemetry/query-layer/README.md
+    (see the "HTTP API contract" section).
+  version: "0.1.0"
+servers:
+  - url: "/projects/{projectId}/control-plane/apis/{telemetryGroup}/v1"
+    description: >-
+      Per-project APIService path. projectId and telemetryGroup are resolved
+      by the kube-aggregator proxy chain, not supplied by API clients directly;
+      they appear here only because OpenAPI requires a concrete server URL
+      template.
+    variables:
+      projectId:
+        default: current
+      telemetryGroup:
+        default: telemetry.datumapis.com
+
+security:
+  - bearerAuth: []
+
+paths:
+  /logs:
+    get:
+      operationId: queryLogs
+      summary: Buffered log query over a time window
+      tags: [logs]
+      parameters:
+        - $ref: "#/components/parameters/LogQLQuery"
+        - $ref: "#/components/parameters/Since"
+        - $ref: "#/components/parameters/Until"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Matching log lines, most recent first.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LogsResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /logs/tail:
+    get:
+      operationId: tailLogs
+      summary: Streaming log query (datumctl logs --tail)
+      description: >-
+        Chunked HTTP response; the connection stays open and new matching log
+        lines are flushed as they are ingested. Delivery is at-least-once —
+        duplicate lines are possible at cursor boundaries, matching the
+        `kubectl logs --follow` contract. Each chunk is one JSON-encoded
+        LogEntry object, newline-delimited.
+      tags: [logs]
+      parameters:
+        - $ref: "#/components/parameters/LogQLQuery"
+        - $ref: "#/components/parameters/Since"
+      responses:
+        "200":
+          description: Newline-delimited stream of LogEntry objects.
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/LogEntry"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /metrics/query:
+    get:
+      operationId: queryMetricsInstant
+      summary: Instant metric query (single point in time)
+      tags: [metrics]
+      parameters:
+        - $ref: "#/components/parameters/PromQLQuery"
+        - name: time
+          in: query
+          description: Evaluation instant. Defaults to now.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: One sample per matching series, evaluated at `time`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /metrics/query_range:
+    get:
+      operationId: queryMetricsRange
+      summary: Range metric query (matrix over [start,end] by step)
+      tags: [metrics]
+      parameters:
+        - $ref: "#/components/parameters/PromQLQuery"
+        - name: start
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: end
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: step
+          in: query
+          required: true
+          description: Resolution step duration, e.g. "30s", "5m".
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A series of samples per matching series across the range.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: >-
+        Forwarded through milo-api; project_id is resolved server-side from
+        this token and is never a client-supplied parameter.
+
+  parameters:
+    LogQLQuery:
+      name: query
+      in: query
+      required: true
+      description: >-
+        LogQL subset: label matchers (`{service_name="foo", severity="ERROR"}`)
+        and line filters (`|= "text"`, `!= "text"`, `|~ "regex"`, `!~ "regex"`).
+        Metric-style aggregations (count_over_time, rate), parser expressions
+        (| json, | logfmt), and line_format/label_format are rejected with 400.
+      schema:
+        type: string
+      example: '{service_name="compute-workload", severity="ERROR"} |= "timeout"'
+
+    PromQLQuery:
+      name: query
+      in: query
+      required: true
+      description: >-
+        PromQL-style label-matched series selector, e.g.
+        `cpu_usage{service="foo"}`. Aggregation functions (sum, avg, rate) are
+        not yet supported and are rejected with 400.
+      schema:
+        type: string
+      example: 'cpu_usage{service="compute-workload"}'
+
+    Since:
+      name: since
+      in: query
+      description: >-
+        Relative ("1h", "30m") or absolute timestamp. Filters ObservedTimestamp.
+        Defaults to 1h before now.
+      schema:
+        type: string
+
+    Until:
+      name: until
+      in: query
+      description: Relative or absolute timestamp upper bound. Defaults to now.
+      schema:
+        type: string
+
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        default: 100
+        maximum: 1000
+        minimum: 1
+
+    Cursor:
+      name: cursor
+      in: query
+      description: Opaque pagination cursor from a previous response's nextCursor.
+      schema:
+        type: string
+
+  responses:
+    BadQuery:
+      description: >-
+        The query parameter failed to parse, or used a construct outside the
+        supported LogQL/PromQL subset.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: Missing or invalid bearer token.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    UnexpectedError:
+      description: >-
+        Any error status not explicitly listed above, including 501 Not
+        Implemented — every handler in the current scaffold is a stub and
+        returns this until the ClickHouse-backed implementation lands.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
+  schemas:
+    Error:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+
+    LogEntry:
+      type: object
+      required: [timestamp, service, severity, body]
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: ObservedTimestamp — set by the OTel Collector on receipt.
+        service:
+          type: string
+        severity:
+          type: string
+          example: ERROR
+        body:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+
+    LogsResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/LogEntry"
+        nextCursor:
+          type: string
+
+    MetricSample:
+      type: object
+      required: [metric, values]
+      properties:
+        metric:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label set for this series, including __name__.
+        values:
+          type: array
+          description: >-
+            [unixTimestamp, stringValue] pairs. A single-element array for
+            /metrics/query; one element per step for /metrics/query_range.
+          items:
+            type: array
+            items: {}
+            minItems: 2
+            maxItems: 2
+
+    MetricsResponse:
+      type: object
+      required: [result]
+      properties:
+        result:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricSample"

--- a/queryapi/openapi.yaml
+++ b/queryapi/openapi.yaml
@@ -17,23 +17,33 @@ info:
     accepts); only the endpoint paths and response envelope changed to match.
 
 
-    Two things this does **not** adopt from real Loki: (1) tenancy is never
-    read from a client-supplied header (real Loki uses `X-Scope-OrgID`, which
-    puts tenancy in the caller's control — see the query-layer design doc's
-    rejection of that model). `project_id` is always resolved server-side from
-    the request context `milo-api` populates, for every endpoint below
-    including label/series discovery — there is no code path where a client
-    can see another project's labels, series, or log lines. (2) `/loki/api/v1/tail`
-    (Loki's live-tail endpoint, a WebSocket upgrade) is intentionally not
-    included in this revision — tracked as a follow-up once the tail
-    transport (chunked HTTP vs. WebSocket) is decided.
+    The metric endpoints mimic the (vanilla) Prometheus HTTP API — plain
+    `/api/v1/query`, not Mimir's `/prometheus/api/v1/query` prefix. "Prometheus"
+    has become the generic term for this query API shape (Grafana's
+    "Prometheus" datasource type is used against Prometheus, Mimir, Cortex,
+    Thanos, and others interchangeably); "Mimir" names one specific product,
+    which this service is not. Matching Prometheus's own paths keeps us
+    generically compatible without implying a specific backend identity.
 
 
-    Metrics (`/metrics/query`, `/metrics/query_range`) are a separate concern
-    from the Loki mimicry above — Loki has no metrics endpoints of its own —
-    and are specced here so `datumctl`/portal work can start, but return 501
-    until implemented.
-  version: "0.2.0"
+    Two things this does **not** adopt from real Loki or real
+    Prometheus/Mimir: (1) tenancy is never read from a client-supplied header
+    (real Loki uses `X-Scope-OrgID`; real Mimir uses the same header for the
+    same purpose — both put tenancy in the caller's control, which the
+    query-layer design doc explicitly rejects). `project_id` is always
+    resolved server-side from the request context `milo-api` populates, for
+    every endpoint below including label/series discovery — there is no code
+    path where a client can see another project's labels, series, samples, or
+    log lines. (2) `/loki/api/v1/tail` (Loki's live-tail endpoint, a WebSocket
+    upgrade) is intentionally not included in this revision — tracked as a
+    follow-up once the tail transport (chunked HTTP vs. WebSocket) is decided.
+
+
+    Metric endpoints are specced here so `datumctl`/portal and Prometheus-API
+    client work can start, but return 501 until implemented — logs are the
+    Phase 1 priority; see the roadmap in
+    enhancements/telemetry/README.md.
+  version: "0.3.0"
 servers:
   - url: "/projects/{projectId}/control-plane/apis/{telemetryGroup}/v1"
     description: >-
@@ -124,7 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LokiStringListResponse"
+                $ref: "#/components/schemas/StringListResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         default:
@@ -165,7 +175,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LokiStringListResponse"
+                $ref: "#/components/schemas/StringListResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -212,7 +222,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LokiSeriesResponse"
+                $ref: "#/components/schemas/SeriesResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -220,10 +230,10 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /metrics/query:
+  /api/v1/query:
     get:
-      operationId: queryMetricsInstant
-      summary: Instant metric query (single point in time)
+      operationId: promQuery
+      summary: Instant metric query (mimics Prometheus's /api/v1/query)
       tags: [metrics]
       parameters:
         - $ref: "#/components/parameters/PromQLQuery"
@@ -233,13 +243,39 @@ paths:
           schema:
             type: string
             format: date-time
+        - $ref: "#/components/parameters/QueryTimeout"
       responses:
         "200":
           description: One sample per matching series, evaluated at `time`.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricsResponse"
+                $ref: "#/components/schemas/PromInstantQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+    post:
+      operationId: promQueryForm
+      summary: >-
+        Instant metric query, form-encoded (Grafana's Prometheus datasource
+        POSTs by default; this is the same operation as GET /api/v1/query)
+      tags: [metrics]
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/PromQueryForm"
+      responses:
+        "200":
+          description: One sample per matching series, evaluated at `time`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromInstantQueryResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -247,10 +283,10 @@ paths:
         default:
           $ref: "#/components/responses/UnexpectedError"
 
-  /metrics/query_range:
+  /api/v1/query_range:
     get:
-      operationId: queryMetricsRange
-      summary: Range metric query (matrix over [start,end] by step)
+      operationId: promQueryRange
+      summary: Range metric query (mimics Prometheus's /api/v1/query_range)
       tags: [metrics]
       parameters:
         - $ref: "#/components/parameters/PromQLQuery"
@@ -262,13 +298,154 @@ paths:
           description: Resolution step duration, e.g. "30s", "5m".
           schema:
             type: string
+        - $ref: "#/components/parameters/QueryTimeout"
       responses:
         "200":
           description: A series of samples per matching series across the range.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MetricsResponse"
+                $ref: "#/components/schemas/PromRangeQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+    post:
+      operationId: promQueryRangeForm
+      summary: >-
+        Range metric query, form-encoded (Grafana's Prometheus datasource
+        POSTs by default; this is the same operation as GET /api/v1/query_range)
+      tags: [metrics]
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/PromQueryRangeForm"
+      responses:
+        "200":
+          description: A series of samples per matching series across the range.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromRangeQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /api/v1/series:
+    get:
+      operationId: promSeries
+      summary: >-
+        List distinct series matching selectors (mimics Prometheus's
+        /api/v1/series)
+      description: >-
+        Same cardinality-bounding concern as `/loki/api/v1/series` applies
+        here: returned series are bounded to a known/allowlisted set of
+        label dimensions, not every dynamic dimension a metric might carry.
+      tags: [discovery]
+      parameters:
+        - name: match[]
+          in: query
+          required: true
+          description: >-
+            One or more PromQL-style selectors, e.g. `cpu_usage{service="foo"}`.
+            At least one is required, matching Prometheus's own /series
+            contract.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+      responses:
+        "200":
+          description: Distinct series (label-sets) matching the given selectors.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesResponse"
+        "400":
+          $ref: "#/components/responses/BadQuery"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /api/v1/labels:
+    get:
+      operationId: promLabelNames
+      summary: >-
+        List label names in use (mimics Prometheus's /api/v1/labels — note
+        the plural, unlike Loki's singular /label)
+      description: >-
+        Scoped to the caller's project_id, same as every other endpoint here.
+      tags: [discovery]
+      parameters:
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+        - name: match[]
+          in: query
+          description: Optional selectors to further scope which series' labels are considered.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+      responses:
+        "200":
+          description: Label names.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StringListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+
+  /api/v1/label/{name}/values:
+    get:
+      operationId: promLabelValues
+      summary: >-
+        List distinct values for one label (mimics Prometheus's
+        /api/v1/label/{name}/values)
+      description: >-
+        Scoped to the caller's project_id, same as every other endpoint here.
+      tags: [discovery]
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: service
+        - $ref: "#/components/parameters/Start"
+        - $ref: "#/components/parameters/End"
+        - name: match[]
+          in: query
+          description: Optional selectors to further scope which series' values are considered.
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+      responses:
+        "200":
+          description: Distinct values for the named label.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StringListResponse"
         "400":
           $ref: "#/components/responses/BadQuery"
         "401":
@@ -347,6 +524,16 @@ components:
         enum: [backward, forward]
         default: backward
 
+    QueryTimeout:
+      name: timeout
+      in: query
+      description: >-
+        Evaluation timeout, e.g. "30s", matching Prometheus's own /query and
+        /query_range timeout param. Accepted for client compatibility; not
+        yet enforced.
+      schema:
+        type: string
+
   responses:
     BadQuery:
       description: >-
@@ -355,13 +542,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/LokiErrorResponse"
+            $ref: "#/components/schemas/ErrorResponse"
     Unauthorized:
       description: Missing or invalid bearer token.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/LokiErrorResponse"
+            $ref: "#/components/schemas/ErrorResponse"
     UnexpectedError:
       description: >-
         Any error status not explicitly listed above, including 501 Not
@@ -371,11 +558,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/LokiErrorResponse"
+            $ref: "#/components/schemas/ErrorResponse"
 
   schemas:
-    LokiErrorResponse:
+    ErrorResponse:
       type: object
+      description: >-
+        Shared by both the Loki-mimicking and Prometheus-mimicking endpoints
+        — Loki's error envelope is itself modeled on Prometheus's.
       required: [status, error]
       properties:
         status:
@@ -386,6 +576,38 @@ components:
           example: bad_data
         error:
           type: string
+
+    StringListResponse:
+      type: object
+      description: >-
+        Shared by the label-name and label-value discovery endpoints, both
+        Loki- and Prometheus-mimicking — same shape in both real APIs.
+      required: [status, data]
+      properties:
+        status:
+          type: string
+          enum: [success]
+        data:
+          type: array
+          items:
+            type: string
+
+    SeriesResponse:
+      type: object
+      description: >-
+        Shared by `/loki/api/v1/series` and `/api/v1/series` — same shape in
+        both real APIs: a list of label-sets, no sample values.
+      required: [status, data]
+      properties:
+        status:
+          type: string
+          enum: [success]
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
 
     LokiStream:
       type: object
@@ -434,33 +656,52 @@ components:
               items:
                 $ref: "#/components/schemas/LokiStream"
 
-    LokiStringListResponse:
+    PromQueryForm:
       type: object
-      required: [status, data]
+      required: [query]
       properties:
-        status:
+        query:
           type: string
-          enum: [success]
-        data:
+        time:
+          type: string
+        timeout:
+          type: string
+
+    PromQueryRangeForm:
+      type: object
+      required: [query, start, end, step]
+      properties:
+        query:
+          type: string
+        start:
+          type: string
+        end:
+          type: string
+        step:
+          type: string
+        timeout:
+          type: string
+
+    PromVectorResult:
+      type: object
+      required: [metric, value]
+      properties:
+        metric:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label set for this series, including __name__.
+        value:
           type: array
+          description: >-
+            [unixTimestamp, stringValue] — a single sample, matching
+            Prometheus's "vector" result type for instant queries.
           items:
             type: string
+          minItems: 2
+          maxItems: 2
 
-    LokiSeriesResponse:
-      type: object
-      required: [status, data]
-      properties:
-        status:
-          type: string
-          enum: [success]
-        data:
-          type: array
-          items:
-            type: object
-            additionalProperties:
-              type: string
-
-    MetricSample:
+    PromMatrixResult:
       type: object
       required: [metric, values]
       properties:
@@ -472,19 +713,56 @@ components:
         values:
           type: array
           description: >-
-            [unixTimestamp, stringValue] pairs. A single-element array for
-            /metrics/query; one element per step for /metrics/query_range.
+            [unixTimestamp, stringValue] pairs, one per step, matching
+            Prometheus's "matrix" result type for range queries.
           items:
             type: array
-            items: {}
+            items:
+              type: string
             minItems: 2
             maxItems: 2
 
-    MetricsResponse:
+    PromInstantQueryResponse:
       type: object
-      required: [result]
+      required: [status, data]
       properties:
-        result:
-          type: array
-          items:
-            $ref: "#/components/schemas/MetricSample"
+        status:
+          type: string
+          enum: [success]
+        data:
+          type: object
+          required: [resultType, result]
+          properties:
+            resultType:
+              type: string
+              enum: [vector]
+              description: >-
+                Always "vector" for the label-matched selector subset this
+                service accepts. Prometheus's "scalar"/"string" result types
+                don't apply to a plain series selector.
+            result:
+              type: array
+              items:
+                $ref: "#/components/schemas/PromVectorResult"
+
+    PromRangeQueryResponse:
+      type: object
+      required: [status, data]
+      properties:
+        status:
+          type: string
+          enum: [success]
+        data:
+          type: object
+          required: [resultType, result]
+          properties:
+            resultType:
+              type: string
+              enum: [matrix]
+              description: >-
+                Always "matrix" for the label-matched selector subset this
+                service accepts.
+            result:
+              type: array
+              items:
+                $ref: "#/components/schemas/PromMatrixResult"


### PR DESCRIPTION
## Summary
- Adds `queryapi/openapi.yaml`: the HTTP contract (logs + metrics endpoints, LogQL/PromQL subset query params, response envelopes) for the telemetry query layer service.
- Lets `datumctl` and customer cloud portal UI/UX work start in parallel with the implementation.

Fixes #78

## Test plan
- [x] Spec validates clean (`npx @redocly/cli lint queryapi/openapi.yaml`)