### PR TITLE
feat: publish otelcol image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,6 +37,21 @@ jobs:
       platforms: linux/amd64,linux/arm64
     secrets: inherit
 
+  publish-otelcol-image:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.14.0
+    with:
+      image-name: o11y/otelcol
+      registry-organization: milo-os
+      context: .
+      dockerfile-path: otelcol/Dockerfile
+      platforms: linux/amd64,linux/arm64
+    secrets: inherit
+
   publish-kustomize-bundles:
     permissions:
       id-token: write

--- a/otelcol/Dockerfile
+++ b/otelcol/Dockerfile
@@ -14,8 +14,14 @@ COPY receiver/natsreceiver/ receiver/natsreceiver/
 COPY otelcol/builder-config.yaml otelcol/builder-config.yaml
 
 WORKDIR /workspace/otelcol
+# Install the builder tool natively (no GOOS/GOARCH override) -- it must
+# run on the build host, not the target platform. Only the collector
+# binary it produces should be cross-compiled; setting GOARCH around a
+# `go run` invocation makes go try to execute the freshly built tool
+# itself as a foreign-arch binary, which fails without QEMU registered.
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.157.0
 RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
-    go run go.opentelemetry.io/collector/cmd/builder@v0.157.0 --config builder-config.yaml
+    "$(go env GOPATH)/bin/builder" --config builder-config.yaml
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /


### PR DESCRIPTION
## Summary
- Wires otelcol's CI image publish (`ghcr.io/milo-os/o11y/otelcol`, real semver/branch/sha tags, no `:latest`) — it had none yet.
- Installs the OCB builder tool natively before cross-compiling: running the builder via `go run` with `GOARCH` set made go try to execute the builder itself as a foreign-arch binary — exec format error in CI, which has no QEMU/binfmt registered for foreign-arch execution. Now installs it natively first, then cross-compiles only the collector artifact.

Split out of #106 into smaller, independent PRs.

## Test plan
- [x] `docker build -f otelcol/Dockerfile .` succeeds with repo-root context
- [x] Verified linux/amd64 and linux/arm64 outputs are genuinely the right architecture (`file(1)`: x86-64 and aarch64 respectively)
- [ ] CI green (lint/test/publish workflows)