### PR TITLE
feat: port edge-collectors and nats config from feat/otel-collector-envoy-compute-logs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,3 +77,16 @@ jobs:
       image-name: ghcr.io/milo-os/telemetry-clickhouse-migrate
       image-overlays: config/clickhouse-migrations
     secrets: inherit
+
+  publish-edge-collectors-kustomize:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
+    with:
+      bundle-name: ghcr.io/milo-os/o11y/edge-collectors-kustomize
+      bundle-path: config/edge-collectors
+      image-name: ghcr.io/milo-os/o11y/otelcol
+      image-overlays: config/edge-collectors
+    secrets: inherit

--- a/config/edge-collectors/gateway-collector.yaml
+++ b/config/edge-collectors/gateway-collector.yaml
@@ -1,0 +1,149 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: gateway-collector
+spec:
+  mode: deployment
+  replicas: 2
+  managementState: managed
+  # Custom distribution (otelcol/) carrying unbatch+nats alongside the
+  # usual contrib set -- this collector publishes to NATS itself, no
+  # bridge collector in between. Tag is overlaid at publish time by the
+  # kustomize-bundle workflow; see .github/workflows/publish.yaml.
+  image: ghcr.io/milo-os/o11y/otelcol:v0.0.0-dev
+  imagePullPolicy: Always
+  observability:
+    metrics:
+      enableMetrics: true
+  env:
+    - name: CLUSTER_NAME
+      value: "${cluster}"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+  config:
+    receivers:
+      # Centralized OTLP push receiver -- for any sender that talks OTLP
+      # natively (Envoy, and now ukp-telemetry too). See README.md.
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 20
+
+      # Splits multi-tenant OTLP batches into one synthetic Resource per
+      # project before milo.project.id derivation, since that attribute is
+      # resource-scoped but a single sender (e.g. Envoy's merged Gateway
+      # fleet) can batch many tenants under one Resource. See README.md.
+      groupbyattrs:
+        keys:
+          - project_name
+
+      # Fallback path: resolves milo.project.id for senders that don't set
+      # project_name themselves, via the sender pod's namespace label.
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.container.name
+            - k8s.deployment.name
+          labels:
+            # See the resource attribute contract in README.md.
+            - tag_name: k8s.namespace.project_name
+              key: resourcemanager.miloapis.com/project-name
+              from: namespace
+            - tag_name: k8s.namespace.upstream_cluster_name
+              key: meta.datumapis.com/upstream-cluster-name
+              from: namespace
+        pod_association:
+          - sources:
+              - from: connection
+
+      resource:
+        attributes:
+          - key: k8s.cluster.name
+            value: $${CLUSTER_NAME}
+            action: upsert
+          - key: service.namespace
+            from_attribute: k8s.namespace.name
+            action: insert
+          - key: service.name
+            from_attribute: k8s.container.name
+            action: insert
+
+      # Derives milo.project.id per the resource attribute contract --
+      # see README.md for the full four-tier precedence.
+      transform/milo_project_id:
+        error_mode: ignore
+        log_statements:
+          - context: resource
+            statements:
+              - >-
+                set(resource.attributes["milo.project.id"], resource.attributes["project_name"])
+                where resource.attributes["project_name"] != nil and
+                resource.attributes["project_name"] != "" and
+                resource.attributes["project_name"] != "-"
+              - >-
+                set(resource.attributes["milo.project.id"], resource.attributes["k8s.namespace.project_name"])
+                where resource.attributes["milo.project.id"] == nil and
+                resource.attributes["k8s.namespace.project_name"] != nil and
+                resource.attributes["k8s.namespace.project_name"] != ""
+              - >-
+                set(resource.attributes["milo.project.id"], resource.attributes["k8s.namespace.upstream_cluster_name"])
+                where resource.attributes["milo.project.id"] == nil and
+                IsMatch(resource.attributes["k8s.namespace.upstream_cluster_name"], "^cluster-")
+              - replace_pattern(resource.attributes["milo.project.id"], "^cluster-", "")
+              - >-
+                set(resource.attributes["milo.project.id"], "internal")
+                where resource.attributes["milo.project.id"] == nil
+              - >-
+                set(resource.attributes["telemetry.subject"], Concat(["telemetry.logs.", resource.attributes["milo.project.id"]], ""))
+
+      batch:
+        timeout: 10s
+        send_batch_size: 512
+
+      # Explodes the batch back down to one record per outgoing message
+      # right before export -- batch above amortizes the enrichment steps'
+      # per-call overhead across many records; this controls the final
+      # message granularity onto NATS. Not redundant with batch: different
+      # jobs, same pipeline.
+      unbatch: {}
+
+    exporters:
+      nats:
+        url: nats.telemetry-system.svc.cluster.local:4222
+        subject_from_attribute: telemetry.subject
+        logs:
+          subject: telemetry.logs.internal
+          encoding: otlp_proto
+
+      debug:
+        verbosity: basic
+        sampling_initial: 5
+        sampling_thereafter: 200
+
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, groupbyattrs, k8sattributes, resource, transform/milo_project_id, batch, unbatch]
+          exporters: [nats, debug]

--- a/config/edge-collectors/gateway-collector.yaml
+++ b/config/edge-collectors/gateway-collector.yaml
@@ -33,7 +33,7 @@ spec:
   config:
     receivers:
       # Centralized OTLP push receiver -- for any sender that talks OTLP
-      # natively (Envoy, and now ukp-telemetry too). See README.md.
+      # natively (e.g. Envoy, ukp-telemetry). See README.md.
       otlp:
         protocols:
           grpc:

--- a/config/edge-collectors/gateway-collector.yaml
+++ b/config/edge-collectors/gateway-collector.yaml
@@ -115,7 +115,7 @@ spec:
                 set(resource.attributes["milo.project.id"], "internal")
                 where resource.attributes["milo.project.id"] == nil
               - >-
-                set(resource.attributes["telemetry.subject"], Concat(["telemetry.logs.", resource.attributes["milo.project.id"]], ""))
+                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["milo.project.id"]], ""))
 
       batch:
         timeout: 10s
@@ -133,7 +133,7 @@ spec:
         url: nats.telemetry-system.svc.cluster.local:4222
         subject_from_attribute: telemetry.subject
         logs:
-          subject: telemetry.logs.internal
+          subject: o11y.logs.internal
           encoding: otlp_proto
 
       debug:

--- a/config/edge-collectors/kustomization.yaml
+++ b/config/edge-collectors/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: telemetry-system
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: telemetry-system
+    includeTemplates: true
+
+resources:
+  - nats.yaml
+  - gateway-collector.yaml
+  - node-agent-collector.yaml

--- a/config/edge-collectors/nats.yaml
+++ b/config/edge-collectors/nats.yaml
@@ -1,0 +1,119 @@
+# Standalone core NATS server (no local JetStream). gateway-collector and
+# node-agent-collector publish logs here directly via the nats exporter.
+# Edge PoPs have no local persistent storage, so this runs core NATS
+# pub/sub only -- no stream, no durability at this hop. It makes a leaf
+# connection (NATS_HUB_LEAFNODE_URL) to a real, storage-backed hub for
+# durability; ClickHouse ingestion off that hub is separate follow-up work.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats-config
+data:
+  nats.conf: |
+    server_name: edge-nats
+    listen: 0.0.0.0:4222
+    tls {
+      cert_file: "/etc/nats-server-tls/tls.crt"
+      key_file: "/etc/nats-server-tls/tls.key"
+      ca_file: "/etc/nats-server-tls/ca.crt"
+      verify: true
+    }
+    http_port: 8222
+    leafnodes {
+      remotes: [
+        {
+          url: $NATS_HUB_LEAFNODE_URL
+          tls: {
+            cert_file: "/etc/nats-leaf-tls/tls.crt"
+            key_file: "/etc/nats-leaf-tls/tls.key"
+            ca_file: "/etc/nats-leaf-tls/ca.crt"
+          }
+        }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      labels:
+        app: nats
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7777"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: metrics
+          image: natsio/prometheus-nats-exporter:v0.20.1
+          args:
+            - -varz
+            - -connz
+            - -subz
+            - -addr=0.0.0.0
+            - -port=7777
+            - http://localhost:8222
+          ports:
+            - name: metrics
+              containerPort: 7777
+        - name: nats
+          image: nats:2.14.2-alpine
+          command: ["nats-server", "-c", "/etc/nats/nats.conf"]
+          env:
+            - name: NATS_HUB_LEAFNODE_URL
+              value: "${hub_leafnode_url}"
+          ports:
+            - name: client
+              containerPort: 4222
+            - name: monitoring
+              containerPort: 8222
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nats
+            - name: nats-leaf-tls
+              mountPath: /etc/nats-leaf-tls
+              readOnly: true
+            - name: nats-server-tls
+              mountPath: /etc/nats-server-tls
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8222
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: nats-config
+        - name: nats-leaf-tls
+          secret:
+            secretName: "${nats_leaf_tls_secret_name}"
+        - name: nats-server-tls
+          secret:
+            secretName: "${local_nats_server_tls_secret_name}"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+spec:
+  selector:
+    app: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitoring
+      port: 8222
+      targetPort: 8222
+    - name: metrics
+      port: 7777
+      targetPort: 7777

--- a/config/edge-collectors/nats.yaml
+++ b/config/edge-collectors/nats.yaml
@@ -3,7 +3,7 @@
 # Edge PoPs have no local persistent storage, so this runs core NATS
 # pub/sub only -- no stream, no durability at this hop. It makes a leaf
 # connection (NATS_HUB_LEAFNODE_URL) to a real, storage-backed hub for
-# durability; ClickHouse ingestion off that hub is separate follow-up work.
+# durability.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/config/edge-collectors/node-agent-collector.yaml
+++ b/config/edge-collectors/node-agent-collector.yaml
@@ -137,7 +137,7 @@ spec:
                 set(resource.attributes["milo.project.id"], "internal")
                 where resource.attributes["milo.project.id"] == nil
               - >-
-                set(resource.attributes["telemetry.subject"], Concat(["telemetry.logs.", resource.attributes["milo.project.id"]], ""))
+                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["milo.project.id"]], ""))
 
       batch:
         timeout: 10s
@@ -155,7 +155,7 @@ spec:
         url: nats.telemetry-system.svc.cluster.local:4222
         subject_from_attribute: telemetry.subject
         logs:
-          subject: telemetry.logs.internal
+          subject: o11y.logs.internal
           encoding: otlp_proto
 
       debug:

--- a/config/edge-collectors/node-agent-collector.yaml
+++ b/config/edge-collectors/node-agent-collector.yaml
@@ -1,6 +1,4 @@
-# Generic node-local agent -- see README.md. SCAFFOLD: node-exporter
-# scrape and generic pod metrics are still TBD; only pod logs are wired
-# up so far.
+# Generic node-local agent -- see README.md.
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:

--- a/config/edge-collectors/node-agent-collector.yaml
+++ b/config/edge-collectors/node-agent-collector.yaml
@@ -1,0 +1,172 @@
+# Generic node-local agent -- see README.md. SCAFFOLD: node-exporter
+# scrape and generic pod metrics are still TBD; only pod logs are wired
+# up so far.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: node-agent-collector
+spec:
+  mode: daemonset
+  managementState: managed
+  # Custom distribution (otelcol/) carrying unbatch+nats alongside the
+  # usual contrib set -- this collector publishes to NATS itself, no
+  # bridge collector in between. Tag is overlaid at publish time by the
+  # kustomize-bundle workflow; see .github/workflows/publish.yaml.
+  image: ghcr.io/milo-os/o11y/otelcol:v0.0.0-dev
+  imagePullPolicy: Always
+  observability:
+    metrics:
+      enableMetrics: true
+  hostNetwork: false
+  # Virtual-kubelet-backed nodes (e.g. Unikraft's kraftlet agents) tolerate
+  # everything via the toleration below but can't pull normal OCI images --
+  # same nodeSelector node-exporter already uses to skip them.
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - operator: Exists
+  volumes:
+    - name: varlogpods
+      hostPath:
+        path: /var/log/pods
+  volumeMounts:
+    - name: varlogpods
+      mountPath: /var/log/pods
+      readOnly: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  env:
+    - name: CLUSTER_NAME
+      value: "${cluster}"
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  config:
+    extensions:
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+        observe_nodes: false
+        # Scoped to this DaemonSet pod's own node -- its hostPath mount
+        # only has that node's log files anyway.
+        node: ${env:K8S_NODE_NAME}
+
+    receivers:
+      # Catch-all for pods that don't push OTLP natively. Discovers pods
+      # dynamically via k8s_observer instead of a static exclude list --
+      # a pod opts out by carrying labels[telemetry.miloapis.com/otlp-native-logs],
+      # rather than someone having to hand-edit this file per domain.
+      receiver_creator/pods:
+        watch_observers: [k8s_observer]
+        receivers:
+          filelog:
+            rule: 'type == "pod.container" && pod.namespace != "telemetry-system" && ("telemetry.miloapis.com/otlp-native-logs" in pod.labels ? pod.labels["telemetry.miloapis.com/otlp-native-logs"] : "") != "true"'
+            config:
+              include: ["/var/log/pods/`pod.namespace`_`pod.name`_`pod.uid`/`container_name`/*.log"]
+              start_at: end
+              include_file_path: true
+              include_file_name: false
+              operators:
+                - id: container-parser
+                  type: container
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 20
+
+      # See README.md for the resource attribute contract. Associates by
+      # k8s.pod.uid rather than connection, since filelog's container
+      # operator already gives us that from the log file path.
+      k8sattributes:
+        auth_type: serviceAccount
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.node.name
+            - k8s.container.name
+            - k8s.deployment.name
+          labels:
+            - tag_name: k8s.namespace.project_name
+              key: resourcemanager.miloapis.com/project-name
+              from: namespace
+            - tag_name: k8s.namespace.upstream_cluster_name
+              key: meta.datumapis.com/upstream-cluster-name
+              from: namespace
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+
+      resource:
+        attributes:
+          - key: k8s.cluster.name
+            value: $${CLUSTER_NAME}
+            action: upsert
+          - key: service.namespace
+            from_attribute: k8s.namespace.name
+            action: insert
+          - key: service.name
+            from_attribute: k8s.container.name
+            action: insert
+
+      transform/milo_project_id:
+        error_mode: ignore
+        log_statements:
+          - context: resource
+            statements:
+              - >-
+                set(resource.attributes["milo.project.id"], resource.attributes["k8s.namespace.project_name"])
+                where resource.attributes["k8s.namespace.project_name"] != nil and
+                resource.attributes["k8s.namespace.project_name"] != ""
+              - >-
+                set(resource.attributes["milo.project.id"], resource.attributes["k8s.namespace.upstream_cluster_name"])
+                where resource.attributes["milo.project.id"] == nil and
+                IsMatch(resource.attributes["k8s.namespace.upstream_cluster_name"], "^cluster-")
+              - replace_pattern(resource.attributes["milo.project.id"], "^cluster-", "")
+              - >-
+                set(resource.attributes["milo.project.id"], "internal")
+                where resource.attributes["milo.project.id"] == nil
+              - >-
+                set(resource.attributes["telemetry.subject"], Concat(["telemetry.logs.", resource.attributes["milo.project.id"]], ""))
+
+      batch:
+        timeout: 10s
+        send_batch_size: 512
+
+      # Explodes the batch back down to one record per outgoing message
+      # right before export -- batch above amortizes the enrichment steps'
+      # per-call overhead across many records; this controls the final
+      # message granularity onto NATS. Not redundant with batch: different
+      # jobs, same pipeline.
+      unbatch: {}
+
+    exporters:
+      nats:
+        url: nats.telemetry-system.svc.cluster.local:4222
+        subject_from_attribute: telemetry.subject
+        logs:
+          subject: telemetry.logs.internal
+          encoding: otlp_proto
+
+      debug:
+        verbosity: basic
+        sampling_initial: 5
+        sampling_thereafter: 200
+
+    service:
+      extensions: [k8s_observer]
+      pipelines:
+        logs:
+          receivers: [receiver_creator/pods]
+          processors: [memory_limiter, k8sattributes, resource, transform/milo_project_id, batch, unbatch]
+          exporters: [nats, debug]


### PR DESCRIPTION
## Summary
- Ports the standalone core-NATS + `gateway-collector`/`node-agent-collector` config from `feat/otel-collector-envoy-compute-logs` onto the restructured repo (`config/edge-collectors/`), following the same porting pattern as `natsreceiver`/`natsexporter`/`unbatchprocessor`.
- Publishes the config as its own Kustomize OCI bundle (`ghcr.io/milo-os/o11y/edge-collectors-kustomize`), mirroring `clickhouse-migrations-kustomize`, for `datum-cloud/infra` to consume.
- All third-party images pinned to real tags (`nats:2.14.2-alpine`, `natsio/prometheus-nats-exporter:v0.20.1`) — none floating on `:latest`.

Split out of #106. Stacked on #107 (otelcol image publish) — this branch includes #107's commit, so its diff will shrink to just this PR's changes once #107 merges.

Note: this only publishes the artifacts. Nothing in `datum-cloud/infra` references them yet — that wiring is separate follow-up work.

## Test plan
- [x] `kustomize build config/edge-collectors` resolves cleanly
- [ ] CI green (lint/test/publish workflows)