### PR TITLE
fix: create the target database if it doesn't exist yet

### DIFF
--- a/clickhouse-migrate/main.go
+++ b/clickhouse-migrate/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	clickhousego "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/golang-migrate/migrate/v4"
@@ -86,6 +87,31 @@ func loadClientTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) 
 	}, nil
 }
 
+// ensureDatabaseExists creates cfg.database if it doesn't already exist,
+// e.g. on a brand-new ClickHouse instance. It connects without pinning the
+// session to that database -- clickhouse-go validates Auth.Database against
+// the server at connect time, so opening a connection already scoped to a
+// not-yet-created database fails before any CREATE DATABASE can run.
+func ensureDatabaseExists(cfg config, tlsConfig *tls.Config) (err error) {
+	bootstrapDB := clickhousego.OpenDB(&clickhousego.Options{
+		Addr: []string{fmt.Sprintf("%s:%s", cfg.host, cfg.port)},
+		Auth: clickhousego.Auth{
+			Username: cfg.username,
+		},
+		TLS: tlsConfig,
+	})
+	defer func() {
+		err = errors.Join(err, bootstrapDB.Close())
+	}()
+
+	_, err = bootstrapDB.Exec("CREATE DATABASE IF NOT EXISTS " + quoteIdentifier(cfg.database))
+	return err
+}
+
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
 func run() error {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
@@ -97,6 +123,11 @@ func run() error {
 	tlsConfig, err := loadClientTLSConfig(cfg.tlsCertFile, cfg.tlsKeyFile, cfg.tlsCAFile)
 	if err != nil {
 		return fmt.Errorf("loading TLS config: %w", err)
+	}
+
+	logger.Info("ensuring database exists", "database", cfg.database)
+	if err := ensureDatabaseExists(cfg, tlsConfig); err != nil {
+		return fmt.Errorf("ensuring database exists: %w", err)
 	}
 
 	db := clickhousego.OpenDB(&clickhousego.Options{

--- a/clickhouse-migrate/main_test.go
+++ b/clickhouse-migrate/main_test.go
@@ -37,6 +37,11 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	require.Equal(t, "/etc/clickhouse-client/certs/tls.crt", cfg.tlsCertFile)
 }
 
+func TestQuoteIdentifier(t *testing.T) {
+	require.Equal(t, "`o11y`", quoteIdentifier("o11y"))
+	require.Equal(t, "`o11y``; DROP TABLE x`", quoteIdentifier("o11y`; DROP TABLE x"))
+}
+
 func TestLoadClientTLSConfig(t *testing.T) {
 	dir := t.TempDir()
 	certFile, keyFile, caFile := writeTestCert(t, dir)


### PR DESCRIPTION
Closes #110

## Summary
- `clickhouse-migrate` opened its migration connection already scoped to `cfg.database` via `Auth.Database`, which clickhouse-go validates against the server at connect time. On a brand-new ClickHouse instance where the database doesn't exist yet, this made `golang-migrate`'s driver fail (`Ping` / `SHOW TABLES FROM <database>`) before migration `000001`'s own `CREATE DATABASE IF NOT EXISTS o11y;` statement ever ran.
- Adds `ensureDatabaseExists`, which bootstraps the database on a separate, unscoped connection first.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` pass in `clickhouse-migrate/`
- [x] Added `TestQuoteIdentifier` for the new identifier-quoting helper