### PR TITLE
feat: add CODEOWNERS naming the SRE team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository.
+* @milo-os/sre


### PR DESCRIPTION
Pull requests here open with no reviewer assigned, so they wait on someone noticing them rather than on someone being asked. Renovate's dependency updates suffer most, since nobody watches for them.

This names the SRE team as the default owner, which puts reviewers on every pull request automatically. SRE already operates the telemetry stack, so it is the honest default until other teams claim specific components.

Related to milo-os/telemetry#105

## Test plan

- [x] SRE team granted write access to this repository
- [x] Review assignment left disabled, so every team member is requested
- [ ] A new pull request auto-requests review from the team
- [ ] A Renovate pull request does the same
