### PR TITLE
Add ClickHouse client-shell manifest and usage docs

### DIFF
--- a/clickhouse-migrate/README.md
+++ b/clickhouse-migrate/README.md
@@ -50,6 +50,23 @@ rule 2, so a bad file fails CI rather than a deploy:
 task clickhouse-migrate:check-migrations
 ```
 
+## Creating a client shell
+
+For when you need to connect to the database via a shell (for instance, to
+recover from a dirty database).
+
+```
+kubectl apply -f ch-shell.yaml
+
+kubectl -n o11y-system exec -it ch-shell -- clickhouse-client \
+  --host chi-clickhouse-o11y-0-0.o11y-system.svc.cluster.local \
+  --port 9440 --secure --user clickhouse-migrations-client
+
+# container has live creds, so delete the container when you're done
+
+kubectl -n o11y-system delete -f ch-shell.yaml
+```
+
 ## Recovering from a dirty database
 
 migrate marks a version dirty *before* running it, so a migration that fails

--- a/clickhouse-migrate/ch-shell.yaml
+++ b/clickhouse-migrate/ch-shell.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: ch-shell-config
+    namespace: o11y-system
+data:
+    config.xml: |
+        <config>
+          <openSSL>
+            <client>
+              <certificateFile>/etc/clickhouse-client/certs/tls.crt</certificateFile>
+              <privateKeyFile>/etc/clickhouse-client/certs/tls.key</privateKeyFile>
+              <caConfig>/etc/clickhouse-client/certs/ca.crt</caConfig>
+              <loadDefaultCAFile>true</loadDefaultCAFile>
+              <verificationMode>relaxed</verificationMode>
+              <invalidCertificateHandler>
+                <name>RejectCertificateHandler</name>
+              </invalidCertificateHandler>
+            </client>
+          </openSSL>
+        </config>
+---
+apiVersion: v1
+kind: Pod
+metadata:
+    name: ch-shell
+    namespace: o11y-system
+spec:
+    restartPolicy: Never
+    securityContext:
+        fsGroup: 101
+    containers:
+        - name: client
+          image: clickhouse/clickhouse-server:25.3-alpine
+          command: ["sleep", "infinity"]
+          volumeMounts:
+              - name: client-certs
+                mountPath: /etc/clickhouse-client/certs
+                readOnly: true
+              - name: client-config
+                mountPath: /etc/clickhouse-client/config.xml
+                subPath: config.xml
+                readOnly: true
+    volumes:
+        - name: client-certs
+          csi:
+              driver: csi.cert-manager.io
+              readOnly: true
+              volumeAttributes:
+                  csi.cert-manager.io/issuer-name: o11y-system
+                  csi.cert-manager.io/issuer-kind: ClusterIssuer
+                  csi.cert-manager.io/common-name: clickhouse-migrations-client
+                  csi.cert-manager.io/duration: 24h
+                  csi.cert-manager.io/key-usages: client auth
+                  csi.cert-manager.io/fs-group: "101"
+        - name: client-config
+          configMap:
+              name: ch-shell-config


### PR DESCRIPTION
Closes #127.

Adds an interactive `clickhouse-client` shell and its usage instructions so engineers can run ad-hoc queries against the o11y ClickHouse when operating or debugging the telemetry pipeline, without hand-rolling a client pod each time. The manifest provisions a shell pod in `o11y-system` that authenticates via client certs issued for the `clickhouse-migrations-client` CN from the `o11y-system` ClusterIssuer, matching the TLS-only pattern the migrations job already uses. Usage is documented in the migration module's README, covering apply, exec into the client shell, and cleanup.

The change has been sitting unmerged on `chore/clickhouse-client-shell` (pushed, never PR'd); this brings it into `main` and closes the tracking issue.

Test plan:
- [ ] `kubectl apply -f ch-shell.yaml` provisions the shell pod in `o11y-system`
- [ ] `kubectl -n o11y-system exec -it ch-shell -- clickhouse-client ...` connects over the secure port using the mounted client certs
- [ ] query returns data (e.g. from `system` tables) without a password
- [ ] `kubectl delete -f ch-shell.yaml` cleans up the pod

