### PR TITLE
Edge→hub NATS leaf: NKey auth over TLS

### DIFF
--- a/config/collectors/gateway-collector.yaml
+++ b/config/collectors/gateway-collector.yaml
@@ -115,7 +115,7 @@ spec:
                 set(resource.attributes["milo.project.id"], "internal")
                 where resource.attributes["milo.project.id"] == nil
               - >-
-                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["milo.project.id"]], ""))
+                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["k8s.cluster.name"], ".", resource.attributes["milo.project.id"]], ""))
 
       batch:
         timeout: 10s
@@ -133,7 +133,7 @@ spec:
         url: nats.o11y-system.svc.cluster.local:4222
         subject_from_attribute: telemetry.subject
         logs:
-          subject: o11y.logs.internal
+          subject: o11y.logs.$${CLUSTER_NAME}.internal
           encoding: otlp_proto
 
       debug:

--- a/config/collectors/nats.yaml
+++ b/config/collectors/nats.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: metrics
-          image: natsio/prometheus-nats-exporter:v0.20.1
+          image: natsio/prometheus-nats-exporter:0.20.1
           args:
             - -varz
             - -connz

--- a/config/collectors/nats.yaml
+++ b/config/collectors/nats.yaml
@@ -19,15 +19,19 @@ data:
       verify: true
     }
     http_port: 8222
+    jetstream {
+      store_dir: "/tmp/js"
+      max_mem: 64MB
+      max_file: 0
+      domain: "edge"
+    }
     leafnodes {
       remotes: [
         {
           url: $NATS_HUB_LEAFNODE_URL
-          tls: {
-            cert_file: "/etc/nats-leaf-tls/tls.crt"
-            key_file: "/etc/nats-leaf-tls/tls.key"
-            ca_file: "/etc/nats-leaf-tls/ca.crt"
-          }
+          # Inline seed only -- nkey does NOT accept a file path.
+          # Injected from the edge-leaf-nkey Secret via env.
+          nkey: $EDGE_NKEY_SEED
         }
       ]
     }
@@ -69,6 +73,11 @@ spec:
           env:
             - name: NATS_HUB_LEAFNODE_URL
               value: "${hub_leafnode_url}"
+            - name: EDGE_NKEY_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: edge-leaf-nkey
+                  key: edge.seed
           ports:
             - name: client
               containerPort: 4222
@@ -77,9 +86,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/nats
-            - name: nats-leaf-tls
-              mountPath: /etc/nats-leaf-tls
-              readOnly: true
             - name: nats-server-tls
               mountPath: /etc/nats-server-tls
               readOnly: true
@@ -93,9 +99,6 @@ spec:
         - name: config
           configMap:
             name: nats-config
-        - name: nats-leaf-tls
-          secret:
-            secretName: "${nats_leaf_tls_secret_name}"
         - name: nats-server-tls
           secret:
             secretName: "${local_nats_server_tls_secret_name}"

--- a/config/collectors/node-agent-collector.yaml
+++ b/config/collectors/node-agent-collector.yaml
@@ -135,7 +135,7 @@ spec:
                 set(resource.attributes["milo.project.id"], "internal")
                 where resource.attributes["milo.project.id"] == nil
               - >-
-                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["milo.project.id"]], ""))
+                set(resource.attributes["telemetry.subject"], Concat(["o11y.logs.", resource.attributes["k8s.cluster.name"], ".", resource.attributes["milo.project.id"]], ""))
 
       batch:
         timeout: 10s
@@ -153,7 +153,7 @@ spec:
         url: nats.o11y-system.svc.cluster.local:4222
         subject_from_attribute: telemetry.subject
         logs:
-          subject: o11y.logs.internal
+          subject: o11y.logs.$${CLUSTER_NAME}.internal
           encoding: otlp_proto
 
       debug:

--- a/exporter/natsexporter/exporter_test.go
+++ b/exporter/natsexporter/exporter_test.go
@@ -96,6 +96,49 @@ func testConfig(t *testing.T, srv *natsserver.Server) *Config {
 	return cfg
 }
 
+// TestPublishToDomainConfiguredServerNeedsNoDomainClient confirms that an
+// acked JetStream publish with no domain configured on the client lands in a
+// stream on a server that *does* configure a JetStream domain. js.Publish only
+// writes to the data subject and awaits a PubAck; it makes no $JS.API call and
+// so does not need the domain to address the API. This is the property that
+// lets the edge exporter publish into the hub's domain with just `stream` set.
+func TestPublishToDomainConfiguredServerNeedsNoDomainClient(t *testing.T) {
+	opts := &natsserver.Options{
+		Host:            "127.0.0.1",
+		Port:            -1,
+		JetStream:       true,
+		JetStreamDomain: "hub",
+		StoreDir:        t.TempDir(),
+	}
+	srv, err := natsserver.NewServer(opts)
+	require.NoError(t, err)
+	go srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		t.Fatal("nats server did not become ready")
+	}
+	t.Cleanup(srv.Shutdown)
+
+	js := createTestStream(t, srv, "o11y", "o11y.>")
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.URL = srv.ClientURL()
+	cfg.Stream = "o11y"
+	cfg.TLS.Insecure = true
+	cfg.Logs.Subject = "o11y.logs.test-cluster.test-project"
+
+	exp, err := newExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+	require.NoError(t, exp.start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, exp.shutdown(t.Context())) })
+
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	require.NoError(t, exp.pushLogs(t.Context(), logs))
+
+	payload := consumeOne(t, js, "o11y", "o11y.logs.test-cluster.test-project")
+	assert.NotEmpty(t, payload)
+}
+
 func TestExporter_PushLogs(t *testing.T) {
 	srv := startTestServer(t)
 	js := createTestStream(t, srv, "otlp", "otlp.>")


### PR DESCRIPTION
Closes #88

Delivers the edge→hub NATS leaf trust hop described in #88 (NKey auth over TLS), validated end-to-end on a digital twin.

### Changes

- **feat(edge): NKey leaf auth over TLS, edge JetStream domain** — the edge NATS connects as a leaf to the hub over TLS, authenticated with a per-PoP NKey (no client-cert, no shared secret); adds an `edge` JetStream domain alongside the hub's `hub`, and the edge collector config changes for NKey leaf auth + `EDGE_NKEY_SEED` injection.
- **feat(collectors): add cluster token to telemetry subject** — subjects become `o11y.<signal>.<cluster>.<project_id>`.
- **test(natsexporter): acked publish works against a domain-configured server** — regression proof that `natsexporter` needs no change to publish into a hub with a JetStream domain.
- **fix(edge): use existing prometheus-nats-exporter image tag 0.20.1** — `v0.20.1` does not exist on Docker Hub.

### Twin validation (2026-08-18)

Against a 3-replica hub with a edge leaf: the leaf attaches into the hub's `O11Y` account via NKey over TLS; cross-domain acked publishes land in the hub stream; two PoPs are isolated in both directions (cross-PoP publishes denied); and revocation (remove the NKey + hub restart) denies the revoked PoP.

### Out of scope (separate)

ClickHouse client-cert auth, Grafana datasource client-cert, and the hub client-port/cluster-route mTLS details remain part of the broader mTLS program, tracked independently.
